### PR TITLE
bitwarden_rs project rename updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Before you start, ensure you have the following:
 
 ## Step 1: Set up Google Cloud `f1-micro` Compute Engine Instance
 
-Google Cloud offers an '[always free](https://cloud.google.com/free/)' tier of their Compute Engine with one virtual core and ~600 MB of RAM (about 150 MB free depending on which OS you installed). [Bitwarden RS](https://github.com/dani-garcia/bitwarden_rs) runs well under these constraints; it's written in Rust and an ideal candidate for a micro instance. 
+Google Cloud offers an '[always free](https://cloud.google.com/free/)' tier of their Compute Engine with one virtual core and ~600 MB of RAM (about 150 MB free depending on which OS you installed). [Vaultwarden](https://github.com/dani-garcia/vaultwarden) runs well under these constraints; it's written in Rust and an ideal candidate for a micro instance. 
 
 Go to [Google Compute Engine](https://cloud.google.com/compute) and open a Cloud Shell. You may also create the instance manually following [the constraints of the free tier](https://cloud.google.com/free/docs/gcp-free-tier). In the Cloud Shell enter the following command to build the properly spec'd machine: 
 

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -1,5 +1,5 @@
 {$DOMAIN}:443 {
-  # Caddy on port 443 in container to bitwarden_rs private instance 
+  # Caddy on port 443 in container to vaultwarden private instance 
   # Use it if Caddy exposed to the net 
   # Doc about automatic HTTPS https://caddyserver.com/docs/automatic-https
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,9 @@ version: '3'
 services:
   bitwarden:
     # Standard Bitwarden is very resource-heavy and cannot run on micro cloud instances
-    # Bitwarden Rust is a Rust (mostly) feature-complete implementation of Bitwarden
-    # https://github.com/dani-garcia/bitwarden_rs
-    image: bitwardenrs/server:alpine
+    # Vaultwarden is a Rust (mostly) feature-complete implementation of Bitwarden
+    # https://github.com/dani-garcia/vaultwarden
+    image: vaultwarden/server:alpine
     restart: always
     container_name: bitwarden
     volumes:
@@ -73,7 +73,7 @@ services:
   fail2ban:
     # Implements fail2ban functionality, banning ips that 
     # try to bruteforce your vault
-    # https://github.com/dani-garcia/bitwarden_rs/wiki/Fail2Ban-Setup
+    # https://github.com/dani-garcia/vaultwarden/wiki/Fail2Ban-Setup
     # https://github.com/crazy-max/docker-fail2ban
     image: crazymax/fail2ban:latest
     restart: always


### PR DESCRIPTION
Bitwarden RS has been renamed to Vaultwarden.

More info here: https://github.com/dani-garcia/vaultwarden/discussions/1642

* Updated all mentions and links of Bitwarden RS to Vaultwarden
* Tested change to `docker-compose.yml` successfully
  * It was just a simple rename for the docker hub image name.