### PR TITLE
Prevent multiple backup crons on bitwarden container restart. And backup dir placeholder

### DIFF
--- a/bitwarden/.gitignore
+++ b/bitwarden/.gitignore
@@ -2,3 +2,6 @@
 *
 # Except this file
 !.gitignore
+
+# Except backups folder
+!/backups

--- a/bitwarden/backups/.gitignore
+++ b/bitwarden/backups/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,8 @@ services:
       sh -c 'if [ -n "$BACKUP" ]; 
              then 
                apk --update --no-cache add sqlite
-               ln -sf /proc/1/fd/1 /var/log/backup.log && 
+               ln -sf /proc/1/fd/1 /var/log/backup.log &&
+               sed -i "/ash .backup.sh /d" /etc/crontabs/root &&
                echo "$BACKUP_SCHEDULE ash /backup.sh $BACKUP" >> /etc/crontabs/root && 
                crond -d 8; 
              fi &&


### PR DESCRIPTION
When I noticed I received 1+n duplicate backup emails n days after docker-compose I checked what was going on. I noticed duplicate entries in /etc/crontab/root being created on each bitwarden docker container restart. This PR prevents the addition of duplicate cron entries.