### PR TITLE
Remove/escape dots in sed commands

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
              then 
                apk --update --no-cache add sqlite
                ln -sf /proc/1/fd/1 /var/log/backup.log &&
-               sed -i "/ash .backup.sh /d" /etc/crontabs/root &&
+               sed -i "/ash \\/backup\\.sh /d" /etc/crontabs/root &&
                echo "$BACKUP_SCHEDULE ash /backup.sh $BACKUP" >> /etc/crontabs/root && 
                crond -d 8; 
              fi &&
@@ -147,7 +147,7 @@ services:
     command: >
       sh -c 'apk --update --no-cache add ipset iptables ip6tables wget bash tzdata &&
              ln -sf /proc/1/fd/1 /var/log/block.log &&
-             sed -i "/bash .block.sh update/d" /etc/crontabs/root &&
+             sed -i "/bash \\/block\\.sh update/d" /etc/crontabs/root &&
              echo "$COUNTRYBLOCK_SCHEDULE bash /block.sh update" >> /etc/crontabs/root &&
              crond -d 8 &&
              bash /block.sh start'    


### PR DESCRIPTION
The current code works, but I suspect that the two dots `.` that match any character were unintended.