### PR TITLE
Update vaultwarden image's tag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     # Standard Bitwarden is very resource-heavy and cannot run on micro cloud instances
     # Vaultwarden is a Rust (mostly) feature-complete implementation of Bitwarden
     # https://github.com/dani-garcia/vaultwarden
-    image: vaultwarden/server:alpine 
+    image: vaultwarden/server:latest-alpine
     restart: always
     container_name: bitwarden
     depends_on: 


### PR DESCRIPTION
See dani-garcia/vaultwarden#4035

`alpine` is currently out of sync, and while they might fix that, it seems they have a preference for `latest-alpine`.