### PR TITLE
Update templates for fail2ban container without included SMTP

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -22,11 +22,11 @@ TZ=
 #SMTP_PASSWORD=
 #SMTP_SECURITY=
 # fail2ban-specific SMTP settings
-# Use TLS to talk to the SMTP server (YES or NO, default NO)
+# Use TLS to talk to the SMTP server (on or off, default off)
 #SMTP_TLS=
-# Specify whether ssmtp does a EHLO/STARTTLS before starting SSL negotiation (YES or NO, default NO)
-# Should probably be YES if SMTP_SECURITY=starttls above
-#SSMTP_STARTTLS=
+# Specify whether ssmtp does a EHLO/STARTTLS before starting SSL negotiation (on or off, default off)
+# Should probably be on if SMTP_SECURITY=starttls above
+#SMTP_STARTTLS=
 
 
 ### BITWARDEN VARIABLES ###

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     image: vaultwarden/server:latest-alpine
     restart: always
     container_name: bitwarden
-    depends_on: 
+    depends_on:
     - proxy
     <<: *default-logging
     volumes:
@@ -54,11 +54,11 @@ services:
     depends_on:
     - bitwarden
     <<: *default-logging
-    volumes: 
+    volumes:
       - ${PWD}/.env:/.env:ro
       - ${PWD}/bitwarden:/data:ro
-      - ${PWD}/bitwarden/rclone:/data/rclone 
-      - ${PWD}/bitwarden/backups:/data/backups 
+      - ${PWD}/bitwarden/rclone:/data/rclone
+      - ${PWD}/bitwarden/backups:/data/backups
     environment:
     - BACKUP                            # Value-less variables are set in .env
     - BACKUP_SCHEDULE
@@ -111,7 +111,7 @@ services:
     restart: always
     container_name: ddns
     <<: *default-logging
-    depends_on: 
+    depends_on:
     - bitwarden
     volumes:
     - ${PWD}/ddns:/config
@@ -121,8 +121,29 @@ services:
     - TZ
 
 
+  # Uncomment if you want fail2ban to send e-mails,
+  # and adjust the depends_on directive in the fail2ban service,
+  # see https://github.com/crazy-max/docker-fail2ban/pull/169/files
+  # msmtpd:
+  #   image: crazymax/msmtpd:latest
+  #   restart: always
+  #   container_name: fail2ban_msmtpd
+  #   ports:
+  #   - "127.0.0.1:2500:2500"
+  #   environment:
+  #   - TZ
+  #   - SMTP_HOST
+  #   - SMTP_PORT
+  #   - SMTP_AUTH=on
+  #   - SMTP_USER=${SMTP_USERNAME}
+  #   - SMTP_PASSWORD
+  #   - SMTP_FROM
+  #   - SMTP_TLS
+  #   - SMTP_STARTTLS
+
+
   fail2ban:
-    # Implements fail2ban functionality, banning ips that 
+    # Implements fail2ban functionality, banning ips that
     # try to bruteforce your vault
     # https://github.com/dani-garcia/vaultwarden/wiki/Fail2Ban-Setup
     # https://github.com/crazy-max/docker-fail2ban
@@ -136,7 +157,6 @@ services:
     - ${PWD}/fail2ban:/data
     - ${PWD}/bitwarden:/bitwarden:ro
     network_mode: "host"
-    privileged: true
     cap_add:
     - NET_ADMIN
     - NET_RAW
@@ -144,13 +164,6 @@ services:
     - F2B_DB_PURGE_AGE=30d
     - F2B_LOG_LEVEL=INFO
     - F2B_IPTABLES_CHAIN=INPUT
-    - SSMTP_HOST=${SMTP_HOST}
-    - SSMTP_PORT=${SMTP_PORT}
-    - SSMTP_USER=${SMTP_USERNAME}
-    - SSMTP_PASSWORD=${SMTP_PASSWORD}
-    - SSMTP_HOSTNAME=Bitwarden (${DOMAIN})
-    - SSMTP_TLS=${SMTP_TLS}
-    - SSMTP_STARTTLS
     - TZ
 
 
@@ -163,7 +176,7 @@ services:
     restart: always
     container_name: countryblock
     <<: *default-logging
-    depends_on: 
+    depends_on:
     - bitwarden
     network_mode: "host"
     privileged: true
@@ -177,14 +190,14 @@ services:
 
 
   watchtower:
-    # Watchtower will pull down your new image, gracefully shut down your existing container 
+    # Watchtower will pull down your new image, gracefully shut down your existing container
     # and restart it with the same options that were used when it was deployed initially
     # https://github.com/containrrr/watchtower
     image: containrrr/watchtower
     restart: always
     container_name: watchtower
     <<: *default-logging
-    depends_on: 
+    depends_on:
     - bitwarden
     volumes:
     - /var/run/docker.sock:/var/run/docker.sock

--- a/fail2ban/jail.d/jail.local
+++ b/fail2ban/jail.d/jail.local
@@ -2,11 +2,8 @@
 bantime = 6h
 findtime = 6h
 maxretry = 5
-# To enable email alerts, uncomment `destemail` and `sender` below,
-# enter your destination and sender emails in the fields,
-# and uncomment the `action_mwl` action in the jails below.
-#destemail = email you want to send to
-#sender = email you want to send from
+# To enable email alerts, uncomment the smtp.py actions in the jails below,
+# entering your destination and sender emails in the appropriate fields
 
 [bitwarden]
 enabled = true
@@ -14,7 +11,7 @@ port = 80,443,8081
 filter = bitwarden
 logpath = /bitwarden/bitwarden.log
 action = iptables-allports[name=bitwarden, chain=FORWARD]
-#         %(action_mwl)s
+#         smtp.py[host=localhost:2500, sendername=Fail2Ban, sender=noreply@mail.com, dest=you@mail.com]
 
 [bitwarden-admin]
 enabled = true
@@ -22,4 +19,4 @@ port = 80,443
 filter = bitwarden-admin
 logpath = /bitwarden/bitwarden.log
 action = iptables-allports[name=bitwarden, chain=FORWARD]
-#         %(action_mwl)s
+#         smtp.py[host=localhost:2500, sendername=Fail2Ban, sender=noreply@mail.com, dest=you@mail.com]


### PR DESCRIPTION
The fail2ban container dropped ssmtp support in crazy-max/docker-fail2ban#169 and now requires a separate container for e-mail relays. The wiki will also need updates.